### PR TITLE
Preserve existing behavior with go1.22/1.23 alias type parsing

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -33,8 +33,9 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/gengo/types"
 	"k8s.io/klog/v2"
+
+	"k8s.io/gengo/types"
 )
 
 // This clarifies when a pkg path has been canonicalized.
@@ -716,6 +717,12 @@ func (b *Builder) walkType(u types.Universe, useName *types.Name, in tc.Type) *t
 	name := tcNameToName(in.String())
 	if useName != nil {
 		name = *useName
+	}
+
+	// Handle alias types conditionally on go1.22+.
+	// Inline this once the minimum supported version is go1.22
+	if out := b.walkAliasType(u, in); out != nil {
+		return out
 	}
 
 	switch t := in.(type) {

--- a/parser/parse_122.go
+++ b/parser/parse_122.go
@@ -1,0 +1,33 @@
+//go:build go1.22
+// +build go1.22
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	gotypes "go/types"
+
+	"k8s.io/gengo/types"
+)
+
+func (b *Builder) walkAliasType(u types.Universe, in gotypes.Type) *types.Type {
+	if t, isAlias := in.(*gotypes.Alias); isAlias {
+		return b.walkType(u, nil, gotypes.Unalias(t))
+	}
+	return nil
+}

--- a/parser/parse_pre_122.go
+++ b/parser/parse_pre_122.go
@@ -1,0 +1,30 @@
+//go:build !go1.22
+// +build !go1.22
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+import (
+	gotypes "go/types"
+
+	"k8s.io/gengo/types"
+)
+
+func (p *Parser) walkAliasType(u types.Universe, in gotypes.Type) *types.Type {
+	return nil
+}


### PR DESCRIPTION
This is the manual backport of the below PR to v1.

Relates: https://github.com/kubernetes/gengo/pull/281